### PR TITLE
Convert Zenoh Client to Micro URIs

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -40,6 +40,7 @@ include_directories(${CMAKE_INSTALL_PREFIX}/include)
 add_definitions(-DSPDLOG_FMT_EXTERNAL)
 
 set(SRC_FILES         
+    src/zenohUri.cpp
     src/zenohUTransport.cpp
     src/zenohRpcClient.cpp
     src/upZenohClient.cpp

--- a/lib/include/up-client-zenoh-cpp/transport/zenohUTransport.h
+++ b/lib/include/up-client-zenoh-cpp/transport/zenohUTransport.h
@@ -115,7 +115,7 @@ namespace uprotocol::utransport {
             
             std::mutex mutex_;
 
-            using uuriKey = size_t;     
+            using uuriKey = std::string;     
             using uuidStr = std::string;
 
             std::unordered_map<uuriKey, z_owned_publisher_t> pubHandleMap_;

--- a/lib/include/up-client-zenoh-cpp/uri/zenohUri.h
+++ b/lib/include/up-client-zenoh-cpp/uri/zenohUri.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 General Motors GTO LLC
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * SPDX-FileType: SOURCE
+ * SPDX-FileCopyrightText: 2024 General Motors GTO LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _ZENOH_URI_
+#define _ZENOH_URI_
+
+#include <string>
+#include <up-core-api/uri.pb.h>
+
+namespace uprotocol::uri {
+
+/// @returns Empty string if unable to serialize the UUri, otherwise UUri
+///          converted to a Zenoh key string
+[[ nodiscard ]] std::string toZenohKeyString(const uprotocol::v1::UUri &u_uri);
+
+} // namespace uprotocol::tools
+
+#endif /*_ZENOH_URI_*/

--- a/lib/src/zenohUri.cpp
+++ b/lib/src/zenohUri.cpp
@@ -66,6 +66,10 @@ std::string toZenohKeyString(const uprotocol::v1::UUri &u_uri) {
         }
     } else if (auto uri = Serializer::serialize(u_uri); uri.empty()) {
         spdlog::error("Serialized micro URI is empty");
+    } else if (uri.size() < Serializer::LocalMicroUriLength) {
+        spdlog::error(
+                "Serialized micro URI has unexpected length of {} (should be "
+                "at least {})", uri.size(), Serializer::LocalMicroUriLength);
     } else {
         if (uri.size() == Serializer::LocalMicroUriLength) {
             topic << local_prefix << separator;

--- a/lib/src/zenohUri.cpp
+++ b/lib/src/zenohUri.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024 General Motors GTO LLC
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * SPDX-FileType: SOURCE
+ * SPDX-FileCopyrightText: 2024 General Motors GTO LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ 
+#include <iomanip>
+#include <sstream>
+#include <spdlog/spdlog.h>
+#include <up-cpp/uri/serializer/MicroUriSerializer.h>
+#include "up-client-zenoh-cpp/session/zenohSessionManager.h"
+
+namespace uprotocol::uri {
+
+namespace {
+void hexlify(auto& topic, const uint8_t byte) {
+    topic << std::hex << std::setw(2) << std::setfill('0');
+    topic << static_cast<int>(byte);
+}
+
+void hexlify(auto& topic, const auto &&start, const auto &&end) {
+    for (auto i = start; i < end; ++i) {
+        hexlify(topic, *i);
+    }
+}
+
+} // anonymous namespace
+
+std::string toZenohKeyString(const uprotocol::v1::UUri &u_uri) {
+    constexpr std::string_view remote_prefix{"upr"};
+    constexpr std::string_view local_prefix{"upl"};
+    constexpr std::string_view separator{"/"};
+    constexpr std::string_view wildcard_suffix{"**"};
+
+    using Serializer = uprotocol::uri::MicroUriSerializer;
+    constexpr auto authority_offset = Serializer::AuthorityStartPosition;
+
+    std::ostringstream topic;
+
+    if (u_uri.has_authority() && !u_uri.has_entity() && !u_uri.has_resource()) {
+        if (auto authority = Serializer::serialize(u_uri.authority()).second;
+                !authority.empty()) {
+            topic << remote_prefix << separator;
+            hexlify(topic, authority.begin(), authority.end());
+            topic << wildcard_suffix;
+        } else {
+            spdlog::error("Serialized micro URI Authority is empty");
+        }
+    } else if (auto uri = Serializer::serialize(u_uri); uri.empty()) {
+        spdlog::error("Serialized micro URI is empty");
+    } else {
+        if (uri.size() == Serializer::LocalMicroUriLength) {
+            topic << local_prefix << separator;
+        } else /* Remote */ {
+            topic << remote_prefix << separator;
+            hexlify(topic, uri.begin() + authority_offset, uri.end());
+            topic << separator;
+        }
+        hexlify(topic, uri.begin(), uri.begin() + authority_offset);
+    }
+
+    return topic.str();
+}
+
+} // namespace uprotocol::tools

--- a/lib/src/zenohUri.cpp
+++ b/lib/src/zenohUri.cpp
@@ -60,7 +60,7 @@ std::string toZenohKeyString(const uprotocol::v1::UUri &u_uri) {
                 !authority.empty()) {
             topic << remote_prefix << separator;
             hexlify(topic, authority.begin(), authority.end());
-            topic << wildcard_suffix;
+            topic << separator << wildcard_suffix;
         } else {
             spdlog::error("Serialized micro URI Authority is empty");
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,19 @@ target_link_libraries(testRpcClient
 
 add_test("t-18-testRpcClient" ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/testRpcClient)
 
+add_executable(testZenohUri
+	src/testZenohUri.cpp)
+target_link_libraries(testZenohUri 
+	PUBLIC
+		up-client-zenoh-cpp::up-client-zenoh-cpp
+		spdlog::spdlog
+	PRIVATE
+		GTest::gtest_main
+		GTest::gmock
+)
+
+add_test("t-18-testZenohUri" ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/testZenohUri)
+
 add_executable(testLatencyPing
 	src/testLatencyPing.cpp)
 

--- a/test/src/testZenohUri.cpp
+++ b/test/src/testZenohUri.cpp
@@ -1,0 +1,259 @@
+// Copyright (c) 2024 General Motors GTO LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// SPDX-FileType: SOURCE
+// SPDX-FileCopyrightText: 2024 General Motors GTO LLC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <spdlog/spdlog.h>
+#include <up-cpp/uri/builder/BuildUUri.h>
+#include <up-cpp/uri/builder/BuildEntity.h>
+#include <up-cpp/uri/builder/BuildUResource.h>
+#include <up-cpp/uri/builder/BuildUAuthority.h>
+#include <up-client-zenoh-cpp/uri/zenohUri.h>
+#include <gtest/gtest.h>
+
+using namespace uprotocol::v1;
+using namespace uprotocol::uri;
+
+TEST(TestZenohUri, UriToZenohKey) {
+    {
+        auto uuri = BuildUUri()
+            .setEntity(BuildUEntity()
+                    .setName("body.access")
+                    .setMajorVersion(1)
+                    .setId(1234)
+                    .build())
+            .setResource(BuildUResource()
+                    .setName("door")
+                    .setInstance("front_left")
+                    .setMessage("Door")
+                    .setID(5678)
+                    .build())
+            .build();
+        auto zKey = toZenohKeyString(uuri);
+
+        EXPECT_EQ(zKey, "upl/0100162e04d20100");
+    }
+    {
+        auto uuri = BuildUUri()
+            .setAutority(BuildUAuthority()
+                    .setIp("10.16.7.4")
+                    .build())
+            .build();
+        auto zKey = toZenohKeyString(uuri);
+
+        EXPECT_EQ(zKey, "upr/0a100704/**");
+    }
+    {
+        auto uuri = BuildUUri()
+            .setAutority(BuildUAuthority()
+                    .setIp("fe00:0:0:98::1")
+                    .build())
+            .build();
+        auto zKey = toZenohKeyString(uuri);
+
+        EXPECT_EQ(zKey, "upr/fe000000000000980000000000000001/**");
+    }
+    {
+        auto uuri = BuildUUri()
+            .setAutority(BuildUAuthority()
+                    .setId({1, 2, 3, 10, 11, 12})
+                    .build())
+            .build();
+        auto zKey = toZenohKeyString(uuri);
+
+        EXPECT_EQ(zKey, "upr/060102030a0b0c/**");
+    }
+    {
+        auto uuri = BuildUUri()
+            .setEntity(BuildUEntity()
+                    .setName("something")
+                    .setMajorVersion(2)
+                    .setId(15)
+                    .build())
+            .setResource(BuildUResource()
+                    .setName("some_other")
+                    .setInstance("thing")
+                    .setMessage("so")
+                    .setID(127)
+                    .build())
+            .setAutority(BuildUAuthority()
+                    .setIp("1.1.1.1")
+                    .build())
+            .build();
+        auto zKey = toZenohKeyString(uuri);
+
+        EXPECT_EQ(zKey, "upr/01010101/0101007f000f0200");
+    }
+    {
+        auto uuri = BuildUUri()
+            .setEntity(BuildUEntity()
+                    .setName("coffee")
+                    .setMajorVersion(0xee)
+                    .setId(0xc0ff)
+                    .build())
+            .setResource(BuildUResource()
+                    .setName("cup")
+                    .setInstance("brewed_coffee")
+                    .setMessage("add_milk")
+                    .setID(0x99)
+                    .build())
+            .setAutority(BuildUAuthority()
+                    .setIp("2001::dead:beef")
+                    .build())
+            .build();
+        auto zKey = toZenohKeyString(uuri);
+
+        EXPECT_EQ(zKey, "upr/200100000000000000000000deadbeef/01020099c0ffee00");
+    }
+    {
+        auto uuri = BuildUUri()
+            .setEntity(BuildUEntity()
+                    .setName("coffee")
+                    .setMajorVersion(0xee)
+                    .setId(0xc0ff)
+                    .build())
+            .setResource(BuildUResource()
+                    .setName("cup")
+                    .setInstance("brewed_coffee")
+                    .setMessage("add_milk")
+                    .setID(0x99)
+                    .build())
+            .setAutority(BuildUAuthority()
+                    .setId({'H', 'e', 'l', 'l', 'o'})
+                    .build())
+            .build();
+        auto zKey = toZenohKeyString(uuri);
+
+        EXPECT_EQ(zKey, "upr/0548656c6c6f/01030099c0ffee00");
+    }
+}
+
+TEST(TestZenohUri, EmptyUUri) {
+    auto uuri = BuildUUri().build();
+    auto zKey = toZenohKeyString(uuri);
+    EXPECT_EQ(zKey, "");
+}
+
+TEST(TestZenohUri, EmptyUEntity) {
+    auto uuri = BuildUUri()
+        .setResource(BuildUResource()
+                .setName("cup")
+                .setInstance("brewed_coffee")
+                .setMessage("add_milk")
+                .setID(0x99)
+                .build())
+        .setAutority(BuildUAuthority()
+                .setId({'H', 'e', 'l', 'l', 'o'})
+                .build())
+        .build();
+    auto zKey = toZenohKeyString(uuri);
+    EXPECT_EQ(zKey, "");
+}
+
+TEST(TestZenohUri, EmptyUResource) {
+    auto uuri = BuildUUri()
+        .setEntity(BuildUEntity()
+                .setName("coffee")
+                .setMajorVersion(0xee)
+                .setId(0xc0ff)
+                .build())
+        .setAutority(BuildUAuthority()
+                .setId({'H', 'e', 'l', 'l', 'o'})
+                .build())
+        .build();
+    auto zKey = toZenohKeyString(uuri);
+    EXPECT_EQ(zKey, "");
+}
+
+TEST(TestZenohUri, LongUri) {
+    {
+        auto uuri = BuildUUri()
+            .setEntity(BuildUEntity()
+                    .setName("coffee")
+                    .setMajorVersion(0xee)
+                    .build())
+            .setResource(BuildUResource()
+                    .setName("cup")
+                    .setInstance("brewed_coffee")
+                    .setMessage("add_milk")
+                    .setID(0x99)
+                    .build())
+            .setAutority(BuildUAuthority()
+                    .setIp("2001::dead:beef")
+                    .build())
+            .build();
+        auto zKey = toZenohKeyString(uuri);
+        EXPECT_EQ(zKey, "");
+    }
+    {
+        auto uuri = BuildUUri()
+            .setEntity(BuildUEntity()
+                    .setName("coffee")
+                    .setMajorVersion(0xee)
+                    .setId(0xc0ff)
+                    .build())
+            .setResource(BuildUResource()
+                    .setName("cup")
+                    .setInstance("brewed_coffee")
+                    .setMessage("add_milk")
+                    .build())
+            .setAutority(BuildUAuthority()
+                    .setIp("2001::dead:beef")
+                    .build())
+            .build();
+        auto zKey = toZenohKeyString(uuri);
+        EXPECT_EQ(zKey, "");
+    }
+    {
+        auto uuri = BuildUUri()
+            .setEntity(BuildUEntity()
+                    .setName("coffee")
+                    .setMajorVersion(0xee)
+                    .setId(0xc0ff)
+                    .build())
+            .setResource(BuildUResource()
+                    .setName("cup")
+                    .setInstance("brewed_coffee")
+                    .setMessage("add_milk")
+                    .setID(0x99)
+                    .build())
+            .setAutority(BuildUAuthority()
+                    .setName("2001::dead:beef")
+                    .build())
+            .build();
+        auto zKey = toZenohKeyString(uuri);
+        EXPECT_EQ(zKey, "");
+    }
+}
+
+TEST(TestZenohUri, LongAuthority) {
+    auto uuri = BuildUUri()
+        .setAutority(BuildUAuthority()
+                .setName("2001::dead:beef")
+                .build())
+        .build();
+    auto zKey = toZenohKeyString(uuri);
+    EXPECT_EQ(zKey, "");
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
~~This change is still a work in progress - the tests are currently failing.~~

[Per Spec](https://github.com/eclipse-uprotocol/up-spec/blob/main/up-l1/zenoh.adoc#22-uri-mapping), the Zenoh client is expected to use a micro URI serialization for the Zenoh keys.

This change switches over to micro URIs.

~~Note: This change is dependent on two PRs: #22 and [up-cpp#75](https://github.com/eclipse-uprotocol/up-cpp/pull/75) and cannot be merged until those are done.~~

~~<b>Please <a href="https://github.com/eclipse-uprotocol/up-client-zenoh-cpp/pull/23/files/012dc3091f72d985c335225df0a318bd9155e892..abaf0ece347ebb167ffce53662729c0e738e14ac">use this link</a> to view only the changes for <em>this</em> PR.</b>~~