### PR TITLE
Address compiler warnings in zenohUri

### DIFF
--- a/lib/src/zenohUri.cpp
+++ b/lib/src/zenohUri.cpp
@@ -31,12 +31,14 @@
 namespace uprotocol::uri {
 
 namespace {
-void hexlify(auto& topic, const uint8_t byte) {
+template<typename TopicT>
+void hexlify(TopicT& topic, const uint8_t byte) {
     topic << std::hex << std::setw(2) << std::setfill('0');
     topic << static_cast<int>(byte);
 }
 
-void hexlify(auto& topic, const auto &&start, const auto &&end) {
+template<typename TopicT, typename IteratorT>
+void hexlify(TopicT& topic, const IteratorT &&start, const IteratorT &&end) {
     for (auto i = start; i < end; ++i) {
         hexlify(topic, *i);
     }


### PR DESCRIPTION
The hexlify function was using auto parameters. While gcc will happily compile that in C++ 17 mode, it does throw warnings because it is a C++ 20 feature.

This changes hexlify to use automatically deduced template types instead of the auto keyword for arguments.