### PR TITLE
Speed up CI jobs with parallelism and caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,13 +155,13 @@ jobs:
           cmake ../ -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local
           cmake --build . --target install --config Release -- -j
 
-      - name: Upload artifacts
+      - name: Upload test binaries
         uses: actions/upload-artifact@v4
         with:
-          name: up-client-zenoh-cpp
-          path: ~/local
+          name: tests_up-client-zenoh-cpp
+          path: |
+            build/bin
           retention-days: 1
-
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,98 +12,139 @@ jobs:
   build-zenoh-c:
     name: Build Zenoh-C
     runs-on: ubuntu-latest
+    env:
+      Zenoh_C_Repo: https://github.com/eclipse-zenoh/zenoh-c.git
+      Zenoh_C_Cache_PFX: libzenohc
+    outputs:
+      Zenoh_C_Cache: ${{ env.Zenoh_C_Cache_PFX }}-${{ steps.zenoh-c-head.outputs.Zenoh_C_HEAD }}
 
     steps:
-      - name: Install Rust toolchain
-        run: rustup component add rustfmt clippy
-
-      - name: Clone Zenoh-C
-        run: |
-          pwd
-          git clone https://github.com/eclipse-zenoh/zenoh-c.git
-          cd zenoh-c && git rev-parse HEAD > .gh_head_rev && cat .gh_head_rev
+      - name: Check remote head hash
+        id: zenoh-c-head
+        shell: bash
+        run: '{ echo -n "Zenoh_C_HEAD="; git ls-remote "$Zenoh_C_Repo" HEAD | cut -f1; } | tee -a "$GITHUB_OUTPUT"'
 
       - name: Cache compiled zenoh-c library
         id: cache-libzenohc
         uses: actions/cache@v4
         with:
-          key: libzenohc-${{ hashFiles('zenoh-c/.gh_head_rev') }}
+          key: ${{ env.Zenoh_C_Cache_PFX }}-${{ steps.zenoh-c-head.outputs.Zenoh_C_HEAD }}
           path: |
             ~/local
+
+      - name: Install Rust toolchain
+        if: ${{ steps.cache-libzenohc.outputs.cache-hit != 'true' }}
+        run: rustup component add rustfmt clippy
+
+      # NOTE: Checks out the head revision we found using ls-remote above
+      #       to avoid race conditions resulting in mismatch between cache
+      #       and contents of repo.
+      - name: Clone Zenoh-C
+        if: ${{ steps.cache-libzenohc.outputs.cache-hit != 'true' }}
+        env:
+          Zenoh_C_HEAD: ${{ steps.zenoh-c-head.outputs.Zenoh_C_HEAD }}
+        shell: bash
+        run: |
+          pwd
+          git clone "$Zenoh_C_Repo"
+          cd zenoh-c && git checkout "$Zenoh_C_HEAD"
 
       - name: Build and install Zenoh-C
         if: ${{ steps.cache-libzenohc.outputs.cache-hit != 'true' }}
         shell: bash
         run: |
-          cd zenoh-c
-          if [ ! -e build ]; then
-            mkdir -p build
-            cd build
-            cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local
-            cd ..
-          fi
-          cd build
+          mkdir -p zenoh-c/build && cd zenoh-c/build
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local
           cmake --build . --target install --config Release -- -j
-
-      - name: Upload artifacts for dependent jobs
-        uses: actions/upload-artifact@v4
-        with:
-          name: libzenohc
-          path: ~/local
-          retention-days: 1
 
   build-up-cpp:
     name: Build up-cpp
     runs-on: ubuntu-latest
+    env:
+      UP_CPP_Repo: https://github.com/eclipse-uprotocol/up-cpp.git
+      UP_CPP_Cache_PFX: up-cpp-conan2
+    outputs:
+      UP_CPP_Cache: ${{ env.UP_CPP_Cache_PFX }}-${{ steps.up-cpp-head.outputs.UP_CPP_HEAD }}
 
     steps:
+      - name: Check remote head hash
+        id: up-cpp-head
+        shell: bash
+        run: '{ echo -n "UP_CPP_HEAD="; git ls-remote "$UP_CPP_Repo" HEAD | cut -f1; } | tee -a "$GITHUB_OUTPUT"'
+
+      - name: Cache conan artifacts
+        id: cache-conan2
+        uses: actions/cache@v4
+        with:
+          key: ${{ env.UP_CPP_Cache_PFX }}-${{ steps.up-cpp-head.outputs.UP_CPP_HEAD }}
+          path: |
+            ~/.conan2
+
       - name: Install Conan
+        if: ${{ steps.cache-conan2.outputs.cache-hit != 'true' }}
         id: conan
         uses: turtlebrowser/get-conan@main
 
       - name: Create default Conan profile
+        if: ${{ steps.cache-conan2.outputs.cache-hit != 'true' }}
         run: conan profile detect
 
+      # NOTE: Checks out the head revision we found using ls-remote above
+      #       to avoid race conditions resulting in mismatch between cache
+      #       and contents of repo.
+      - name: Clone up-cpp repo
+        if: ${{ steps.cache-conan2.outputs.cache-hit != 'true' }}
+        shell: bash
+        env:
+          UP_CPP_HEAD: ${{ steps.up-cpp-head.outputs.UP_CPP_HEAD }}
+        run: |
+          git clone "$UP_CPP_Repo"
+          cd up-cpp && git checkout "$UP_CPP_HEAD"
+          git submodule update --init --recursive
+
       - name: Create up-cpp Conan package
+        if: ${{ steps.cache-conan2.outputs.cache-hit != 'true' }}
         shell: bash
         run: |
-          git clone https://github.com/eclipse-uprotocol/up-cpp.git
           cd up-cpp
-          git submodule update --init --recursive
           conan create . --build=missing
 
-      - name: Upload artifacts for dependent jobs
-        uses: actions/upload-artifact@v4
-        with:
-          name: up-cpp-conan2
-          path: ~/.conan2
-          retention-days: 1
+      - name: Clean up conan build files
+        if: ${{ steps.cache-conan2.outputs.cache-hit != 'true' }}
+        run: conan cache clean '*'
 
   build-up-client-zenoh-cpp:
     name: Build up-client-zenoh-cpp
     needs: [ build-zenoh-c, build-up-cpp ]
     runs-on: ubuntu-latest
+    env:
+      Zenoh_C_Cache: ${{ needs.build-zenoh-c.outputs.Zenoh_C_Cache }}
+      UP_CPP_Cache: ${{ needs.build-up-cpp.outputs.UP_CPP_Cache }}
 
     steps:
-      - name: Download libzenohc
-        uses: actions/download-artifact@v4
+      # Note: will never update here since it will always match from previous job
+      - name: Get cached zenoh-c library
+        uses: actions/cache@v4
         with:
-          name: libzenohc
-          path: ~/local
+          key: ${{ env.Zenoh_C_Cache }}
+          path: |
+            ~/local
 
-      - name: Download up-cpp conan packages
-        uses: actions/download-artifact@v4
+      # Note: will never update here since it will always match from previous job
+      - name: Get cached up-cpp conan artifacts
+        uses: actions/cache@v4
         with:
-          name: up-cpp-conan2
-          path: ~/.conan2
-
-      - uses: actions/checkout@v4
+          key: ${{ env.UP_CPP_Cache }}
+          path: |
+            ~/.conan2
 
       - name: Install Conan
         id: conan
         uses: turtlebrowser/get-conan@main
 
-      - name: Build && install up-client-zenoh-cpp
+      - uses: actions/checkout@v4
+
+      - name: Build and install up-client-zenoh-cpp
         shell: bash
         run: |
           export CMAKE_PREFIX_PATH="$HOME/local"
@@ -114,8 +155,14 @@ jobs:
           cmake ../ -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local
           cmake --build . --target install --config Release -- -j
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: up-client-zenoh-cpp
+          path: ~/local
+          retention-days: 1
 
-  
+
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
   # from branches where specific status checks have passed. These checks are

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,26 +9,60 @@ on:
   workflow_dispatch:
   
 jobs:
-  build:
-    name: Build
+  build-zenoh-c:
+    name: Build Zenoh-C
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: rustup component add rustfmt clippy
 
+      - name: Clone Zenoh-C
+        run: |
+          pwd
+          git clone https://github.com/eclipse-zenoh/zenoh-c.git
+          cd zenoh-c && git rev-parse HEAD > .gh_head_rev && cat .gh_head_rev
+
+      - name: Cache compiled zenoh-c library
+        id: cache-libzenohc
+        uses: actions/cache@v4
+        with:
+          key: libzenohc-${{ hashFiles('zenoh-c/.gh_head_rev') }}
+          path: |
+            ~/local
+
+      - name: Build and install Zenoh-C
+        if: ${{ steps.cache-libzenohc.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          cd zenoh-c
+          if [ ! -e build ]; then
+            mkdir -p build
+            cd build
+            cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local
+            cd ..
+          fi
+          cd build
+          cmake --build . --target install --config Release -- -j
+
+      - name: Upload artifacts for dependent jobs
+        uses: actions/upload-artifact@v4
+        with:
+          name: libzenohc
+          path: ~/local
+          retention-days: 1
+
+  build-up-cpp:
+    name: Build up-cpp
+    runs-on: ubuntu-latest
+
+    steps:
       - name: Install Conan
         id: conan
         uses: turtlebrowser/get-conan@main
 
-      - name: Conan version
-        run: echo "${{ steps.conan.outputs.version }}"
-
-
       - name: Create default Conan profile
         run: conan profile detect
-
-      - name: Install Rust toolchain
-        run: rustup component add rustfmt clippy
 
       - name: Create up-cpp Conan package
         shell: bash
@@ -38,13 +72,36 @@ jobs:
           git submodule update --init --recursive
           conan create . --build=missing
 
-      - name: Build and install Zenoh-C
-        shell: bash
-        run: |
-          git clone https://github.com/eclipse-zenoh/zenoh-c.git
-          cd zenoh-c && mkdir -p build && cd build 
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local
-          cmake --build . --target install --config Release -- -j
+      - name: Upload artifacts for dependent jobs
+        uses: actions/upload-artifact@v4
+        with:
+          name: up-cpp-conan2
+          path: ~/.conan2
+          retention-days: 1
+
+  build-up-client-zenoh-cpp:
+    name: Build up-client-zenoh-cpp
+    needs: [ build-zenoh-c, build-up-cpp ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download libzenohc
+        uses: actions/download-artifact@v4
+        with:
+          name: libzenohc
+          path: ~/local
+
+      - name: Download up-cpp conan packages
+        uses: actions/download-artifact@v4
+        with:
+          name: up-cpp-conan2
+          path: ~/.conan2
+
+      - uses: actions/checkout@v4
+
+      - name: Install Conan
+        id: conan
+        uses: turtlebrowser/get-conan@main
 
       - name: Build && install up-client-zenoh-cpp
         shell: bash
@@ -67,7 +124,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: build
+    needs: [ build-zenoh-c, build-up-cpp, build-up-client-zenoh-cpp ]
     if: always()
     steps:
       - name: Check whether all jobs pass


### PR DESCRIPTION
While diagnosing CI issues in [up-zenoh-example-cpp](/eclipse-uprotocol/up-zenoh-example-cpp), I got stuck waiting for zenoh-c to build over and over again.

![must go faster](https://github.com/eclipse-uprotocol/up-client-zenoh-cpp/assets/10570177/504598b0-cd30-4cd7-9b4c-20b331cd5541)

This PR is my attempt to speed up the CI builds in a way that can be applied both here and in up-zenoh-example-cpp. The two main time savings are from:

1. Running non-dependent builds in parallel (up-cpp and zenoh-c)
2. Caching results from input dependencies

Caches are based on the repo's HEAD hash, and will be regenerated whenever HEAD moves in up-cpp or zenoh-c. Additionally, GitHub actions isolates caches per-branch, so each new PR from a new branch will _start_ by rebuilding up-cpp and zenoh-c. Each subsequent update will reuse the caches.

Before this change, [typical build times](https://github.com/eclipse-uprotocol/up-client-zenoh-cpp/actions/runs/8638059277) were around 5 minutes. After this change, builds [with primed caches](https://github.com/gregmedd/up-client-zenoh-cpp/actions/runs/8653246515) finish in around 1 minute, while fresh builds can _sometimes_ be up to 30 seconds faster than before (there is some variability in GitHub's infrastructure).